### PR TITLE
Extend timeout for image prepulling

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -29,7 +29,7 @@ done
 SCRIPT_ROOT=$(cd `dirname $0` && pwd)
 kubectl create -f ${SCRIPT_ROOT}/prepull.yaml
 # Wait 10 minutes for the test images to be pulled onto the nodes.
-sleep 10m
+sleep 15m
 # Check the status of the pods.
 kubectl get pods -o wide
 # Delete the pods anyway since pre-pulling is best-effort


### PR DESCRIPTION
The 10min timeout is not sufficient. Bumping it to 15 min for now. Need to watch if this would cause the test to time out entirely. Alternatively, we can probably remove some test images as we suspect not all of them are used in our current tests.

GCE:
```
NAME            READY   STATUS       RESTARTS   AGE   IP          NODE                                           NOMINATED NODE   READINESS GATES
prepull-2ts4z   0/1     Init:34/38   0          10m   10.64.2.3   e2e-75b7839e30-36623-windows-node-group-149g   <none>           <none>
prepull-54kdr   0/1     Init:35/38   0          10m   10.64.3.3   e2e-75b7839e30-36623-windows-node-group-96h6   <none>           <none>
prepull-kzvql   0/1     Init:34/38   0          10m   10.64.1.3   e2e-75b7839e30-36623-windows-node-group-k7rn   <none>           <none>
```

GKE (slower):
```
NAME            READY   STATUS       RESTARTS   AGE   IP          NODE                                                  NOMINATED NODE   READINESS GATES
prepull-6vn78   0/1     Init:22/38   0          10m   10.12.2.3   gke-e2e-603e6b5005-39504-windows-pool-be058335-91hw   <none>           <none>
prepull-qts52   0/1     Init:21/38   0          10m   10.12.4.3   gke-e2e-603e6b5005-39504-windows-pool-be058335-qfk0   <none>           <none>
prepull-smjxw   0/1     Init:22/38   0          10m   10.12.3.3   gke-e2e-603e6b5005-39504-windows-pool-be058335-tsrg   <none>           <none>
```